### PR TITLE
Added Dart to file extensions

### DIFF
--- a/src/declarations/fileExtensions.ts
+++ b/src/declarations/fileExtensions.ts
@@ -36,6 +36,7 @@ export const fileExtensions = {
 	'routing.ts': '_file_angular-routing',
 	'routing.js': '_file_angular-routing',
 	'routing.dart': '_file_angular-routing',
+	dart: '_file_dart',
 	cs: '_file_csharp',
 	csx: '_file_csharp',
 	coffee: '_file_coffee',

--- a/src/declarations/languageIds.ts
+++ b/src/declarations/languageIds.ts
@@ -14,6 +14,7 @@ export const languageIds = {
 	coffeescript: '_file_coffee',
 	css: '_file_css',
 	d: '_file_dlang',
+	dart: '_file_dart',
 	dscript: '_file_dlang',
 	dml: '_file_dlang',
 	diet: '_file_dlang',


### PR DESCRIPTION
Was working on a flutter project and was annoyed that the dart files had no icons. I did see that the dart logo icon was in this project but it was still missing in the config. I did add the dart file type to the fileExtensions.ts which fixed the problem.